### PR TITLE
Removing mention of Ops Metrics.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -70,9 +70,7 @@ addresses, and click **Save**.
 
     <%= image_tag("guide/ntp_servers.png") %>
 
-1. Select **Health Monitor**. This field should be left blank unless you have
-installed Pivotal Ops Metrics.
-Only set an IP address _after_ you install Pivotal Ops Metrics.
+1. Select **Health Monitor**. This field should be left blank. This is reserved for future use.
 
     <%= image_tag("guide/health_monitor.png") %>
 


### PR DESCRIPTION
Not everyone will have access to Ops Metrics Beta in 1.1. While its too late to change the text in the product, we can remove it from this doc for now.
