### PR TITLE
Adding a line for PCF install instructions for Azure

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -25,5 +25,6 @@ Once you have completed the steps in this guide, explore the documentation on
 ## <a id='install'></a>Install Pivotal Cloud Foundry&reg;:
 
 * <a href="../customizing/cloudform.html" class="subnav">Installing Pivotal Cloud Foundry&reg; on AWS</a>
+* <a href="../customizing/pcf_azure.html" class="subnav">Installing Pivotal Cloud Foundry&reg; on Azure</a>
 * <a href="../customizing/openstack.html" class="subnav">Installing Pivotal Cloud Foundry&reg; on OpenStack</a>
 * <a href="../customizing/vsphere.html" class="subnav">Installing Pivotal Cloud Foundry&reg; on vSphere and vCloud Air</a>


### PR DESCRIPTION
Your Installing PCF doc does not have the link to installing PCF for Azure.  I have added a line below the AWS line to contain the link to the Azure installation instructions.  

Cheers!

Sean Clark - Cloud Solution Architect - Microsoft - @vseanclark