### PR TITLE
Adding "Table of Contents" to the title

### DIFF
--- a/pcf-docs.html.md.erb
+++ b/pcf-docs.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Pivotal Cloud Foundry Documentation
+title: Pivotal Cloud Foundry Documentation Table of Contents
 ---
 
 <ol class="class-list">


### PR DESCRIPTION
When this page shows up in search it is weird because the title just shows up as "Pivotal Cloud Foundry Documentation"... Like, I know I'm looking at the documentation :)